### PR TITLE
fix(cai_tool.py): remove main() redefinition

### DIFF
--- a/c2pa/cai_tool.py
+++ b/c2pa/cai_tool.py
@@ -562,10 +562,5 @@ def main():
     process(assertions, claim, store_label)
 
 
-def main():
-    script = sys.argv[0]
-    process()
-
-
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Remove redefinition of `main()` in `cai_tool.py` which causes error when executing the script